### PR TITLE
[Tech-Day] Added filtering projects by 'topic' value

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Run `$ lein run --` to see the docs.
 Examples:
 
 ```
-$ lein run -- create-tag 1.0.0 "my amazing tag" https://gitlab.com/api/v4 186 $TOKEN --dry-run --excludes-file=excludes.txt
-$ lein run -- start-pipeline https://gitlab.com/api/v4 186 $TOKEN --dry-run --branch=master --excludes-file=excludes.txt
-$ lein run -- create-tag 1.0.0 "release" https://gitlab.com/api/v4 186 $TOKEN --includes-file=includes.txt
+$ lein run -- create-tag 1.0.0 "my amazing tag" https://gitlab.com/api/v4 186 releasable $TOKEN --dry-run --excludes-file=excludes.txt
+$ lein run -- start-pipeline https://gitlab.com/api/v4 186 releasable $TOKEN --dry-run --branch=master --excludes-file=excludes.txt
+$ lein run -- create-tag 1.0.0 "release" https://gitlab.com/api/v4 186 releasable $TOKEN --includes-file=includes.txt
 ```
 
 ## Filtering projects

--- a/src/gitlab_group_actions/cli.clj
+++ b/src/gitlab_group_actions/cli.clj
@@ -14,14 +14,15 @@
                             :exit-status  (arg-map "exit-status")
                             :group-id     (if (arg-map "<group-id>") (Integer/parseInt (arg-map "<group-id>")))
                             :recursive    (or (arg-map "--recursive") false)
+                            :topic        (arg-map "<topic>")
                             :tag-name     (arg-map "<name>")
                             :tag-message  (arg-map "<message>")})
 
 (defn #^{:doc     "Gitlab Group Actions.
 
 Usage:
-  gl_ga start-pipeline <api-url> <group-id> <access-token> [-r -n -b=<branch> -x=<excludes_file> -i=<includes_file>]
-  gl_ga create-tag <name> <message> <api-url> <group-id> <access-token> [-r -n -b=<branch> -x=<excludes_file> -i=<includes_file>]
+  gl_ga start-pipeline <api-url> <group-id> <topic> <access-token> [-r -n -b=<branch> -x=<excludes_file> -i=<includes_file>]
+  gl_ga create-tag <name> <message> <api-url> <group-id> <topic> <access-token> [-r -n -b=<branch> -x=<excludes_file> -i=<includes_file>]
   gl_ga -h | --help
   gl_ga -v | --version
 

--- a/src/gitlab_group_actions/projects.clj
+++ b/src/gitlab_group_actions/projects.clj
@@ -28,11 +28,11 @@
                                                           projects)))
 
 (defn get-projects
-  ([{:keys [:access-token :api-url :group-id :recursive :excludes :includes]} page]
+  ([{:keys [:access-token :api-url :group-id :recursive :topic :excludes :includes]} page]
    (let [resp (api/get
                access-token
-               "%s/groups/%d/projects?include_subgroups=%b&simple=true&archived=false&per_page=100&page=%d"
-               [api-url group-id recursive page])
+               "%s/groups/%d/projects?include_subgroups=%b&topic=%s&simple=true&archived=false&per_page=100&page=%d"
+               [api-url group-id recursive topic page])
          body (:body resp)
          total_pages (Integer/parseInt (:x-total-pages (:headers resp)))]
      (if (> total_pages page) (throw (new IllegalStateException "OMG THERE ARE MORE PAGEZZZ"))) ; TODO


### PR DESCRIPTION
We opt for another approach rather than having a `whitelist` or a `blacklist`.

We labeled/marked projects that are eligible for the release with a `releasable` topic (the formal `labels` in the GitLab world).
The scripts are modified in a way to filter by a specified topic via the GitLab API.

In this way, we have a simpler command to run and no need to track/filter out the needed or non-needed repos.